### PR TITLE
feat: add support for TYPO3 v14

### DIFF
--- a/Classes/DataProcessing/JsonProcessor.php
+++ b/Classes/DataProcessing/JsonProcessor.php
@@ -9,13 +9,10 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 class JsonProcessor implements DataProcessorInterface
 {
     /**
-    * Process data of a record to resolve File objects to the view
-    *
-    * @param ContentObjectRenderer $cObj The data of the content element or page
-    * @param array<string, string> $contentObjectConfiguration The configuration of Content Object
-    * @param array<string, string> $processorConfiguration The configuration of this processor
-    * @param array<string, array<string, string>> $processedData Key/value store of processed data (e.g. to be passed to a Fluid View)
-    * @return array<string, array<string, string>> the processed data as key/value store
+    * @param array<string, string> $contentObjectConfiguration
+    * @param array<string, string> $processorConfiguration
+    * @param array<string, mixed> $processedData
+    * @return array<string, mixed>
     */
     public function process(
         ContentObjectRenderer $cObj,
@@ -23,26 +20,31 @@ class JsonProcessor implements DataProcessorInterface
         array $processorConfiguration,
         array $processedData
     ): array {
+        /** @var array<string, string|int|null> $data */
+        $data = $processedData['data'] ?? [];
         $jsonText = '';
 
-        if (!$processedData['data']['tx_bwstatictemplate_from_file'] && $processedData['data']['tx_bwstatictemplate_json']) {
-            $jsonText = $processedData['data']['tx_bwstatictemplate_json'];
+        if (!$data['tx_bwstatictemplate_from_file'] && $data['tx_bwstatictemplate_json']) {
+            $jsonText = (string)$data['tx_bwstatictemplate_json'];
         }
 
-        if ($processedData['data']['tx_bwstatictemplate_from_file'] && $processedData['data']['tx_bwstatictemplate_file_path']) {
-            if (str_starts_with($processedData['data']['tx_bwstatictemplate_file_path'], 'http')) {
-                $fileUrl = $processedData['data']['tx_bwstatictemplate_file_path'];
-                $jsonText = GeneralUtility::getUrl($fileUrl);
+        if ($data['tx_bwstatictemplate_from_file'] && $data['tx_bwstatictemplate_file_path']) {
+            $filePath = (string)$data['tx_bwstatictemplate_file_path'];
+            if (str_starts_with($filePath, 'http')) {
+                $jsonText = GeneralUtility::getUrl($filePath);
             } else {
-                $filePath = GeneralUtility::getFileAbsFileName($processedData['data']['tx_bwstatictemplate_file_path']);
-                $jsonText = $filePath ? file_get_contents($filePath) : '';
+                $absPath = GeneralUtility::getFileAbsFileName($filePath);
+                $jsonText = $absPath ? file_get_contents($absPath) : '';
             }
         }
 
         if ($jsonText) {
-            $json = json_decode($jsonText, true);
+            /** @var array<string, mixed>|null $json */
+            $json = json_decode((string)$jsonText, true);
             if ($json !== null) {
-                $processedData = array_merge_recursive($processedData, (array)$json);
+                /** @var array<string, mixed> $merged */
+                $merged = array_merge_recursive($processedData, $json);
+                $processedData = $merged;
             }
         }
 

--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -12,7 +12,6 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
@@ -28,6 +27,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
         $html = '';
+        /** @var array<string, string|int|null> $row */
         $row = $item->getRecord();
 
         // custom preview
@@ -52,7 +52,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // append images (not in custom preview)
         if (!$row['tx_bwstatictemplate_be_template'] && $row['assets']) {
-            $html .= BackendUtility::thumbCode(
+            $html .= (string)BackendUtility::thumbCode(
                 $row,
                 'tt_content',
                 'assets',
@@ -70,7 +70,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     }
 
     /**
-    * @param array<string, string> $row
+    * @param array<string, string|int|null> $row
     */
     protected function renderTablePreview(array $row): string
     {
@@ -99,7 +99,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     }
 
     /**
-    * @param array<string, string> $row
+    * @param array<string, string|int|null> $row
     * @return array<string, mixed>
     */
     protected function getJson(array $row): array
@@ -108,21 +108,21 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // fetch from file (or remote)
         if ($row['tx_bwstatictemplate_from_file'] && $row['tx_bwstatictemplate_file_path']) {
-            $isRemoteUrl = GeneralUtility::isValidUrl($row['tx_bwstatictemplate_file_path']);
+            $filePathOrUrl = (string)$row['tx_bwstatictemplate_file_path'];
+            $isRemoteUrl = GeneralUtility::isValidUrl($filePathOrUrl);
 
             if ($isRemoteUrl) {
-                $fileUrl = $row['tx_bwstatictemplate_file_path'];
                 try {
-                    $jsonText = GeneralUtility::getUrl($fileUrl);
+                    $jsonText = GeneralUtility::getUrl($filePathOrUrl);
                 } catch (\Exception $e) {
                     $this->errorTitle = 'Error loading JSON';
-                    $this->errorMessage = 'Could not fetch data from remote "' . $fileUrl . '"';
+                    $this->errorMessage = 'Could not fetch data from remote "' . $filePathOrUrl . '"';
                     return [];
                 }
             }
 
             if (!$isRemoteUrl) {
-                $filePath = GeneralUtility::getFileAbsFileName($row['tx_bwstatictemplate_file_path']);
+                $filePath = GeneralUtility::getFileAbsFileName($filePathOrUrl);
                 if (file_exists($filePath)) {
                     $jsonText = file_get_contents($filePath);
                 } else {
@@ -135,7 +135,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // use from database
         if (!$row['tx_bwstatictemplate_from_file'] && $row['tx_bwstatictemplate_json']) {
-            $jsonText = $row['tx_bwstatictemplate_json'];
+            $jsonText = (string)$row['tx_bwstatictemplate_json'];
         }
 
         // empty json
@@ -145,7 +145,9 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // decode
         try {
-            return (array)json_decode($jsonText, true, 512, JSON_THROW_ON_ERROR);
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($jsonText, true, 512, JSON_THROW_ON_ERROR);
+            return $decoded;
         } catch (\Exception $e) {
             $this->errorTitle = 'Error decoding JSON';
             $this->errorMessage = 'No valid JSON data';
@@ -229,19 +231,24 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
     protected function getLanguageService(): LanguageService
     {
-        return $GLOBALS['LANG'] ?? GeneralUtility::makeInstance(LanguageService::class);
+        /** @var LanguageService $languageService */
+        $languageService = $GLOBALS['LANG'] ?? GeneralUtility::makeInstance(LanguageService::class);
+        return $languageService;
     }
 
     /**
-    * @param array<string, string> $row
+    * @param array<string, string|int|null> $row
     */
     protected function renderFluidBackendTemplate(array $row): string
     {
+        /** @var array<string, mixed> $typoScript */
         $typoScript = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
         $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
-        /** @var array<string, array<int, string>> $viewSettings */
-        $viewSettings = $typoScriptService->convertTypoScriptArrayToPlainArray($typoScript['lib.']['contentElement.']);
-        $templateName = $row['tx_bwstatictemplate_be_template'];
+        /** @var array<string, mixed> $libConfig */
+        $libConfig = $typoScript['lib.'] ?? [];
+        /** @var array{templateRootPaths: array<int, string>, partialRootPaths: array<int, string>, layoutRootPaths: array<int, string>} $viewSettings */
+        $viewSettings = $typoScriptService->convertTypoScriptArrayToPlainArray((array)($libConfig['contentElement.'] ?? []));
+        $templateName = (string)$row['tx_bwstatictemplate_be_template'];
 
         // set template name and root path from EXT:name/Resources/Private/Templates/Show.html
         if (str_starts_with($templateName, 'EXT:')) {
@@ -263,7 +270,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
                 templateRootPaths: $viewSettings['templateRootPaths'],
                 partialRootPaths: $viewSettings['partialRootPaths'],
                 layoutRootPaths: $viewSettings['layoutRootPaths'],
-                request: $GLOBALS['TYPO3_REQUEST'] ?? null,
+                request: ($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof \Psr\Http\Message\ServerRequestInterface ? $GLOBALS['TYPO3_REQUEST'] : null,
             );
             /** @var \TYPO3\CMS\Core\View\ViewFactoryInterface $viewFactory */
             $viewFactory = GeneralUtility::getContainer()->get(\TYPO3\CMS\Core\View\ViewFactoryInterface::class);

--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -21,6 +21,9 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     protected string $errorMessage = '';
 
     protected string $errorTitle = '';
+    public function __construct(private readonly \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer, private readonly \TYPO3\CMS\Extbase\Configuration\ConfigurationManager $configurationManager)
+    {
+    }
 
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
@@ -35,7 +38,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
         // default view
         if (!$row['tx_bwstatictemplate_be_template']) {
             $html = $row['tx_bwstatictemplate_template_path'] ? '<p><strong>' . $row['tx_bwstatictemplate_template_path'] . '</strong></p>' : '';
-            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+            $pageRenderer = $this->pageRenderer;
             $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance()
             );
@@ -234,7 +237,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     */
     protected function renderFluidBackendTemplate(array $row): string
     {
-        $typoScript = GeneralUtility::makeInstance(ConfigurationManager::class)->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+        $typoScript = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
         $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
         /** @var array<string, array<int, string>> $viewSettings */
         $viewSettings = $typoScriptService->convertTypoScriptArrayToPlainArray($typoScript['lib.']['contentElement.']);
@@ -247,14 +250,28 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
             $templateName = ContentElementUserFunc::getTemplateNameFromPath($templateName);
         }
 
-        $view = GeneralUtility::makeInstance(StandaloneView::class);
-        $view->setTemplateRootPaths($viewSettings['templateRootPaths']);
-        $view->setLayoutRootPaths($viewSettings['layoutRootPaths']);
-        $view->setPartialRootPaths($viewSettings['partialRootPaths']);
-        $view->setTemplate($templateName);
+        if (class_exists(StandaloneView::class)) {
+            // TYPO3 v12/v13
+            $view = GeneralUtility::makeInstance(StandaloneView::class);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateRootPaths($viewSettings['templateRootPaths']);
+            $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths($viewSettings['layoutRootPaths']);
+            $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths($viewSettings['partialRootPaths']);
+            $view->getRenderingContext()->setControllerAction($templateName);
+        } else {
+            // TYPO3 v14+ (StandaloneView removed)
+            $viewFactoryData = new \TYPO3\CMS\Core\View\ViewFactoryData(
+                templateRootPaths: $viewSettings['templateRootPaths'],
+                partialRootPaths: $viewSettings['partialRootPaths'],
+                layoutRootPaths: $viewSettings['layoutRootPaths'],
+                request: $GLOBALS['TYPO3_REQUEST'] ?? null,
+            );
+            /** @var \TYPO3\CMS\Core\View\ViewFactoryInterface $viewFactory */
+            $viewFactory = GeneralUtility::getContainer()->get(\TYPO3\CMS\Core\View\ViewFactoryInterface::class);
+            $view = $viewFactory->create($viewFactoryData);
+        }
 
         /** @var PageRenderer $pageRenderer */
-        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer = $this->pageRenderer;
         $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
             JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance($row['uid'])
         );
@@ -270,7 +287,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
         }
 
         try {
-            $html = $view->render();
+            $html = class_exists(StandaloneView::class) ? $view->render() : $view->render($templateName);
             return is_string($html) ? $html : '';
         } catch (\Exception $e) {
             $this->errorTitle = 'Error rendering preview';

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -5,9 +5,9 @@
     'tt_content',
     'CType',
     [
-        'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.title',
-        'bw_static_template',
-        'tx_bwstatictemplate_pi1',
+        'label' => 'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.title',
+        'value' => 'bw_static_template',
+        'icon' => 'tx_bwstatictemplate_pi1',
     ],
     'html',
     'after'
@@ -83,7 +83,7 @@ $GLOBALS['TCA']['tt_content']['palettes']['templates'] = [
 
 $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
     'showitem' => '
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+        --div--;core.form.tabs:general,
             --palette--;;general,
             --palette--;;templates,
             --palette--;;json,
@@ -91,16 +91,16 @@ $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
         --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
             --palette--;;frames,
             --palette--;;appearanceLinks,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+        --div--;core.form.tabs:language,
             --palette--;;language,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
+        --div--;core.form.tabs:access,
             --palette--;;hidden,
             --palette--;;access,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
+        --div--;core.form.tabs:categories,
             categories,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
+        --div--;core.form.tabs:notes,
             rowDescription,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
+        --div--;core.form.tabs:extended,
     ',
 ];
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -83,7 +83,7 @@ $GLOBALS['TCA']['tt_content']['palettes']['templates'] = [
 
 $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
     'showitem' => '
-        --div--;core.form.tabs:general,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
             --palette--;;general,
             --palette--;;templates,
             --palette--;;json,
@@ -91,16 +91,16 @@ $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
         --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
             --palette--;;frames,
             --palette--;;appearanceLinks,
-        --div--;core.form.tabs:language,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
             --palette--;;language,
-        --div--;core.form.tabs:access,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
             --palette--;;hidden,
             --palette--;;access,
-        --div--;core.form.tabs:categories,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
             categories,
-        --div--;core.form.tabs:notes,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
             rowDescription,
-        --div--;core.form.tabs:extended,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
     ',
 ];
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-json": "*",
 		"ext-pdo": "*",
 		"blueways/bw-jsoneditor": "^2.0",
-		"typo3/cms-core": "^12.3 || ^13.4"
+		"typo3/cms-core": "^12.3 || ^13.4 || ^14.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
@@ -27,9 +27,8 @@
 		"friendsoftypo3/content-blocks": "^0.7.18 || ^1.0.0",
 		"helhum/typo3-console": "^8.1",
 		"helmich/typo3-typoscript-lint": "^3.2",
-		"nikic/php-parser": "4.19.4 as 5.3.1",
-		"saschaegerer/phpstan-typo3": "^1.1",
-		"ssch/typo3-rector": "^2.10",
+		"saschaegerer/phpstan-typo3": "^1.1 || ^2.0",
+		"ssch/typo3-rector": "^2.10 || ^3.0",
 		"symfony/translation": "^7.1",
 		"typo3/cms-base-distribution": "^12.0 || ^13.4",
 		"typo3/cms-lowlevel": "^12.0 || ^13.4"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,7 +6,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'templates',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
+            'typo3' => '12.4.0-14.3.99',
             'bw_jsoneditor' => '2.0.0-2.99.99',
         ],
         'conflicts' => [

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 * This file is part of the TYPO3 CMS project.
 *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,121 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		-
+			message: '#^Method Blueways\\BwStaticTemplate\\DataProcessing\\JsonProcessor\:\:process\(\) should return array\<string, array\<string, string\>\> but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/DataProcessing/JsonProcessor.php
+
+		-
+			message: '#^Binary operation "\." between ''\<p\>\<strong\>'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Binary operation "\.\=" between non\-falsy\-string and mixed results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot access offset ''contentElement\.'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getJson\(\) should return array\<string, mixed\> but returns array\<mixed, mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getLanguageService\(\) should return TYPO3\\CMS\\Core\\Localization\\LanguageService but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderFluidBackendTemplate\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderTablePreview\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \#1 \$typoScriptArray of method TYPO3\\CMS\\Core\\TypoScript\\TypoScriptService\:\:convertTypoScriptArrayToPlainArray\(\) expects array\<int\|string, mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \$request of class TYPO3\\CMS\\Core\\View\\ViewFactoryData constructor expects Psr\\Http\\Message\\ServerRequestInterface\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Binary operation "\.\=" between mixed and '',tx…'' results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''bw_static_template'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''ctrl'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''json'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''label_alt'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''palettes'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''templates'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''tt_content'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''typeicon_classes'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''types'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,62 +1,8 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method Blueways\\BwStaticTemplate\\DataProcessing\\JsonProcessor\:\:process\(\) should return array\<string, array\<string, string\>\> but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/DataProcessing/JsonProcessor.php
-
-		-
-			message: '#^Binary operation "\." between ''\<p\>\<strong\>'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
 			message: '#^Binary operation "\.\=" between non\-falsy\-string and mixed results in an error\.$#'
 			identifier: assignOp.invalid
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Cannot access offset ''contentElement\.'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getJson\(\) should return array\<string, mixed\> but returns array\<mixed, mixed\>\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getLanguageService\(\) should return TYPO3\\CMS\\Core\\Localization\\LanguageService but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderFluidBackendTemplate\(\) expects array\<string, string\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderTablePreview\(\) expects array\<string, string\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \#1 \$typoScriptArray of method TYPO3\\CMS\\Core\\TypoScript\\TypoScriptService\:\:convertTypoScriptArrayToPlainArray\(\) expects array\<int\|string, mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \$request of class TYPO3\\CMS\\Core\\View\\ViewFactoryData constructor expects Psr\\Http\\Message\\ServerRequestInterface\|null, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: Classes/PreviewRenderer/BackendPreviewRender.php
 

--- a/rector.php
+++ b/rector.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\ValueObject\PhpVersion;
-use Ssch\TYPO3Rector\CodeQuality\General\ConvertImplicitVariablesToExplicitGlobalsRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
@@ -16,7 +15,6 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/Classes',
         __DIR__ . '/Configuration',
-        __DIR__ . '/config',
         __DIR__ . '/ext_emconf.php',
         __DIR__ . '/ext_tables.php',
     ])
@@ -26,7 +24,7 @@ return RectorConfig::configure()
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-        Typo3LevelSetList::UP_TO_TYPO3_13,
+        Typo3LevelSetList::UP_TO_TYPO3_14,
     ])
     // To have a better analysis from PHPStan, we teach it here some more things
     ->withPHPStanConfigs([
@@ -34,11 +32,10 @@ return RectorConfig::configure()
     ])
     ->withRules([
         AddVoidReturnTypeWhereNoReturnRector::class,
-        ConvertImplicitVariablesToExplicitGlobalsRector::class,
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.3.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-13.4.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.4.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-14.3.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     // If you use withImportNames(), you should consider excluding some TYPO3 files.

--- a/rector.php
+++ b/rector.php
@@ -42,6 +42,8 @@ return RectorConfig::configure()
     ->withSkip([
         // @see https://github.com/sabbelasichon/typo3-rector/issues/2536
         __DIR__ . '/**/Configuration/ExtensionBuilder/*',
+        // Keep LLL:EXT: tab labels for TYPO3 v12 compatibility (core.form.tabs:* is v14+ only)
+        __DIR__ . '/Configuration/TCA/Overrides/tt_content.php',
         NameImportingPostRector::class => [
             'ext_localconf.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html
             'ext_tables.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html


### PR DESCRIPTION
 Add TYPO3 v14 compatibility while keeping v12 and v13 support.                                                                                                                                                                                                                                                                                                                                                           
                                                        
## Changes

  - Version constraints: `typo3/cms-core extended` to `^12.3 || ^13.4 || ^14.0`, ext_emconf updated to `12.4.0-14.3.99`
  - `StandaloneView` migration: Replaced with `ViewFactoryInterface` for TYPO3 v14 (removed in v14), with class_exists() fallback for v12/v13

##  Dependencies

  Requires https://github.com/maikschneider/bw_jsoneditor/pull/4 for blueways/bw-jsoneditor v14 support.
