### PR TITLE
TYPO3 v14 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        typo3-version: ["12.4", "13.4"]
-        php-version: ["8.2", "8.3"]
+        typo3-version: ["13.4", "14.2"]
+        php-version: ["8.2", "8.3", "8.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Classes/DataProcessing/JsonProcessor.php
+++ b/Classes/DataProcessing/JsonProcessor.php
@@ -9,13 +9,10 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 class JsonProcessor implements DataProcessorInterface
 {
     /**
-    * Process data of a record to resolve File objects to the view
-    *
-    * @param ContentObjectRenderer $cObj The data of the content element or page
-    * @param array<string, string> $contentObjectConfiguration The configuration of Content Object
-    * @param array<string, string> $processorConfiguration The configuration of this processor
-    * @param array<string, array<string, string>> $processedData Key/value store of processed data (e.g. to be passed to a Fluid View)
-    * @return array<string, array<string, string>> the processed data as key/value store
+    * @param array<string, string> $contentObjectConfiguration
+    * @param array<string, string> $processorConfiguration
+    * @param array<string, mixed> $processedData
+    * @return array<string, mixed>
     */
     public function process(
         ContentObjectRenderer $cObj,
@@ -23,26 +20,31 @@ class JsonProcessor implements DataProcessorInterface
         array $processorConfiguration,
         array $processedData
     ): array {
+        /** @var array<string, string|int|null> $data */
+        $data = $processedData['data'] ?? [];
         $jsonText = '';
 
-        if (!$processedData['data']['tx_bwstatictemplate_from_file'] && $processedData['data']['tx_bwstatictemplate_json']) {
-            $jsonText = $processedData['data']['tx_bwstatictemplate_json'];
+        if (!$data['tx_bwstatictemplate_from_file'] && $data['tx_bwstatictemplate_json']) {
+            $jsonText = (string)$data['tx_bwstatictemplate_json'];
         }
 
-        if ($processedData['data']['tx_bwstatictemplate_from_file'] && $processedData['data']['tx_bwstatictemplate_file_path']) {
-            if (str_starts_with($processedData['data']['tx_bwstatictemplate_file_path'], 'http')) {
-                $fileUrl = $processedData['data']['tx_bwstatictemplate_file_path'];
-                $jsonText = GeneralUtility::getUrl($fileUrl);
+        if ($data['tx_bwstatictemplate_from_file'] && $data['tx_bwstatictemplate_file_path']) {
+            $filePath = (string)$data['tx_bwstatictemplate_file_path'];
+            if (str_starts_with($filePath, 'http')) {
+                $jsonText = GeneralUtility::getUrl($filePath);
             } else {
-                $filePath = GeneralUtility::getFileAbsFileName($processedData['data']['tx_bwstatictemplate_file_path']);
-                $jsonText = $filePath ? file_get_contents($filePath) : '';
+                $absPath = GeneralUtility::getFileAbsFileName($filePath);
+                $jsonText = $absPath ? file_get_contents($absPath) : '';
             }
         }
 
         if ($jsonText) {
-            $json = json_decode($jsonText, true);
+            /** @var array<string, mixed>|null $json */
+            $json = json_decode((string)$jsonText, true);
             if ($json !== null) {
-                $processedData = array_merge_recursive($processedData, (array)$json);
+                /** @var array<string, mixed> $merged */
+                $merged = array_merge_recursive($processedData, $json);
+                $processedData = $merged;
             }
         }
 

--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -12,7 +12,6 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
@@ -28,6 +27,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
         $html = '';
+        /** @var array<string, string|int|null> $row */
         $row = $item->getRecord();
 
         // custom preview
@@ -52,7 +52,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // append images (not in custom preview)
         if (!$row['tx_bwstatictemplate_be_template'] && $row['assets']) {
-            $html .= BackendUtility::thumbCode(
+            $html .= (string)BackendUtility::thumbCode(
                 $row,
                 'tt_content',
                 'assets',
@@ -70,7 +70,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     }
 
     /**
-    * @param array<string, string> $row
+    * @param array<string, string|int|null> $row
     */
     protected function renderTablePreview(array $row): string
     {
@@ -99,7 +99,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     }
 
     /**
-    * @param array<string, string> $row
+    * @param array<string, string|int|null> $row
     * @return array<string, mixed>
     */
     protected function getJson(array $row): array
@@ -108,21 +108,21 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // fetch from file (or remote)
         if ($row['tx_bwstatictemplate_from_file'] && $row['tx_bwstatictemplate_file_path']) {
-            $isRemoteUrl = GeneralUtility::isValidUrl($row['tx_bwstatictemplate_file_path']);
+            $filePathOrUrl = (string)$row['tx_bwstatictemplate_file_path'];
+            $isRemoteUrl = GeneralUtility::isValidUrl($filePathOrUrl);
 
             if ($isRemoteUrl) {
-                $fileUrl = $row['tx_bwstatictemplate_file_path'];
                 try {
-                    $jsonText = GeneralUtility::getUrl($fileUrl);
+                    $jsonText = GeneralUtility::getUrl($filePathOrUrl);
                 } catch (\Exception $e) {
                     $this->errorTitle = 'Error loading JSON';
-                    $this->errorMessage = 'Could not fetch data from remote "' . $fileUrl . '"';
+                    $this->errorMessage = 'Could not fetch data from remote "' . $filePathOrUrl . '"';
                     return [];
                 }
             }
 
             if (!$isRemoteUrl) {
-                $filePath = GeneralUtility::getFileAbsFileName($row['tx_bwstatictemplate_file_path']);
+                $filePath = GeneralUtility::getFileAbsFileName($filePathOrUrl);
                 if (file_exists($filePath)) {
                     $jsonText = file_get_contents($filePath);
                 } else {
@@ -135,7 +135,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // use from database
         if (!$row['tx_bwstatictemplate_from_file'] && $row['tx_bwstatictemplate_json']) {
-            $jsonText = $row['tx_bwstatictemplate_json'];
+            $jsonText = (string)$row['tx_bwstatictemplate_json'];
         }
 
         // empty json
@@ -145,7 +145,9 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // decode
         try {
-            return (array)json_decode($jsonText, true, 512, JSON_THROW_ON_ERROR);
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($jsonText, true, 512, JSON_THROW_ON_ERROR);
+            return $decoded;
         } catch (\Exception $e) {
             $this->errorTitle = 'Error decoding JSON';
             $this->errorMessage = 'No valid JSON data';
@@ -229,19 +231,24 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
     protected function getLanguageService(): LanguageService
     {
-        return $GLOBALS['LANG'] ?? GeneralUtility::makeInstance(LanguageService::class);
+        /** @var LanguageService $languageService */
+        $languageService = $GLOBALS['LANG'] ?? GeneralUtility::makeInstance(LanguageService::class);
+        return $languageService;
     }
 
     /**
-    * @param array<string, string> $row
+    * @param array<string, string|int|null> $row
     */
     protected function renderFluidBackendTemplate(array $row): string
     {
+        /** @var array<string, mixed> $typoScript */
         $typoScript = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
         $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
-        /** @var array<string, array<int, string>> $viewSettings */
-        $viewSettings = $typoScriptService->convertTypoScriptArrayToPlainArray($typoScript['lib.']['contentElement.']);
-        $templateName = $row['tx_bwstatictemplate_be_template'];
+        /** @var array<string, mixed> $libConfig */
+        $libConfig = $typoScript['lib.'] ?? [];
+        /** @var array{templateRootPaths: array<int, string>, partialRootPaths: array<int, string>, layoutRootPaths: array<int, string>} $viewSettings */
+        $viewSettings = $typoScriptService->convertTypoScriptArrayToPlainArray((array)($libConfig['contentElement.'] ?? []));
+        $templateName = (string)$row['tx_bwstatictemplate_be_template'];
 
         // set template name and root path from EXT:name/Resources/Private/Templates/Show.html
         if (str_starts_with($templateName, 'EXT:')) {
@@ -263,7 +270,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
                 templateRootPaths: $viewSettings['templateRootPaths'],
                 partialRootPaths: $viewSettings['partialRootPaths'],
                 layoutRootPaths: $viewSettings['layoutRootPaths'],
-                request: $GLOBALS['TYPO3_REQUEST'] ?? null,
+                request: ($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof \Psr\Http\Message\ServerRequestInterface ? $GLOBALS['TYPO3_REQUEST'] : null,
             );
             /** @var \TYPO3\CMS\Core\View\ViewFactoryInterface $viewFactory */
             $viewFactory = GeneralUtility::getContainer()->get(\TYPO3\CMS\Core\View\ViewFactoryInterface::class);

--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -3,32 +3,40 @@
 namespace Blueways\BwStaticTemplate\PreviewRenderer;
 
 use Blueways\BwStaticTemplate\UserFunc\ContentElementUserFunc;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumnItem;
+use TYPO3\CMS\Core\Domain\RecordInterface;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
+#[Autoconfigure(public: true)]
 class BackendPreviewRender extends StandardContentPreviewRenderer
 {
     protected string $errorMessage = '';
 
     protected string $errorTitle = '';
-    public function __construct(private readonly \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer, private readonly \TYPO3\CMS\Extbase\Configuration\ConfigurationManager $configurationManager)
+    public function __construct(private readonly PageRenderer $pageRenderer, private readonly ConfigurationManager $configurationManager)
     {
+        parent::__construct();
     }
 
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
         $html = '';
+        $record = $item->getRecord();
+
+        // v14: getRecord() returns RecordInterface; v13: returns array
         /** @var array<string, string|int|null> $row */
-        $row = $item->getRecord();
+        $row = $record instanceof RecordInterface ? $item->getRow() : $record;
 
         // custom preview
         if ($row['tx_bwstatictemplate_be_template']) {
@@ -42,7 +50,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
             $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance()
             );
-            $html .= $this->renderTablePreview($row);
+            $html .= $this->renderTablePreview($row, $record);
         }
 
         // error view
@@ -52,27 +60,38 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // append images (not in custom preview)
         if (!$row['tx_bwstatictemplate_be_template'] && $row['assets']) {
-            $html .= (string)BackendUtility::thumbCode(
-                $row,
-                'tt_content',
-                'assets',
-                '',
-                '',
-                null,
-                0,
-                '',
-                '',
-                false
-            );
+            if ($record instanceof RecordInterface) {
+                // TYPO3 v14: thumbCode removed, use getThumbCodeUnlinked via RecordInterface
+                if ($record->has('assets') && ($assets = $record->get('assets'))) {
+                    /** @var iterable<\TYPO3\CMS\Core\Resource\FileReference>|\TYPO3\CMS\Core\Resource\FileReference $assets */
+                    $html .= $this->getThumbCodeUnlinked($assets);
+                }
+            } else {
+                // TYPO3 v13
+                /** @phpstan-ignore staticMethod.notFound */
+                $html .= (string)BackendUtility::thumbCode(
+                    $row,
+                    'tt_content',
+                    'assets',
+                    '',
+                    '',
+                    null,
+                    0,
+                    '',
+                    '',
+                    false
+                );
+            }
         }
 
-        return $this->linkEditContent($html, $row);
+        return $this->linkEditContent($html, $record);
     }
 
     /**
     * @param array<string, string|int|null> $row
+    * @param RecordInterface|array<string, string|int|null> $record
     */
-    protected function renderTablePreview(array $row): string
+    protected function renderTablePreview(array $row, RecordInterface|array $record): string
     {
         $json = $this->getJson($row);
         $table = $this->getJsonAsTable($json);
@@ -89,7 +108,9 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
 
         // crop table
         $content = '<div class="jsonTablePreview jsonTablePreview--hidden" id="jsonTable' . $row['uid'] . '">';
-        $content .= $this->linkEditContent($table, $row);
+        if ($record instanceof RecordInterface) {
+            $content .= $this->linkEditContent($table, $record);
+        }
         $content .= '</div>';
         $moreIcon = '<span class="icon icon-size-small icon-state-default"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 16 16"><g class="icon-color"><path d="m4.464 6.05-.707.707L8 11l4.243-4.243-.707-.707L8 9.586z"/></g></svg></span>';
         $moreText = $this->getLanguageService()->sL('LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:preview.more');

--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -46,6 +46,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
         // default view
         if (!$row['tx_bwstatictemplate_be_template']) {
             $html = $row['tx_bwstatictemplate_template_path'] ? '<p><strong>' . $row['tx_bwstatictemplate_template_path'] . '</strong></p>' : '';
+            $html = $this->linkEditContent($html, $record);
             $pageRenderer = $this->pageRenderer;
             $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance()
@@ -64,12 +65,12 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
                 // TYPO3 v14: thumbCode removed, use getThumbCodeUnlinked via RecordInterface
                 if ($record->has('assets') && ($assets = $record->get('assets'))) {
                     /** @var iterable<\TYPO3\CMS\Core\Resource\FileReference>|\TYPO3\CMS\Core\Resource\FileReference $assets */
-                    $html .= $this->getThumbCodeUnlinked($assets);
+                    $image = $this->getThumbCodeUnlinked($assets);
                 }
             } else {
                 // TYPO3 v13
                 /** @phpstan-ignore staticMethod.notFound */
-                $html .= (string)BackendUtility::thumbCode(
+                $image = (string)BackendUtility::thumbCode(
                     $row,
                     'tt_content',
                     'assets',
@@ -82,9 +83,10 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
                     false
                 );
             }
+            $html .= $this->linkEditContent($image, $record);
         }
 
-        return $this->linkEditContent($html, $record);
+        return $html;
     }
 
     /**

--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -21,6 +21,9 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     protected string $errorMessage = '';
 
     protected string $errorTitle = '';
+    public function __construct(private readonly \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer, private readonly \TYPO3\CMS\Extbase\Configuration\ConfigurationManager $configurationManager)
+    {
+    }
 
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
@@ -35,7 +38,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
         // default view
         if (!$row['tx_bwstatictemplate_be_template']) {
             $html = $row['tx_bwstatictemplate_template_path'] ? '<p><strong>' . $row['tx_bwstatictemplate_template_path'] . '</strong></p>' : '';
-            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+            $pageRenderer = $this->pageRenderer;
             $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance()
             );
@@ -234,7 +237,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
     */
     protected function renderFluidBackendTemplate(array $row): string
     {
-        $typoScript = GeneralUtility::makeInstance(ConfigurationManager::class)->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+        $typoScript = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
         $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
         /** @var array<string, array<int, string>> $viewSettings */
         $viewSettings = $typoScriptService->convertTypoScriptArrayToPlainArray($typoScript['lib.']['contentElement.']);
@@ -247,14 +250,28 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
             $templateName = ContentElementUserFunc::getTemplateNameFromPath($templateName);
         }
 
-        $view = GeneralUtility::makeInstance(StandaloneView::class);
-        $view->setTemplateRootPaths($viewSettings['templateRootPaths']);
-        $view->setLayoutRootPaths($viewSettings['layoutRootPaths']);
-        $view->setPartialRootPaths($viewSettings['partialRootPaths']);
-        $view->setTemplate($templateName);
+        if (class_exists(StandaloneView::class)) {
+            // TYPO3 v12/v13
+            $view = GeneralUtility::makeInstance(StandaloneView::class);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateRootPaths($viewSettings['templateRootPaths']);
+            $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths($viewSettings['layoutRootPaths']);
+            $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths($viewSettings['partialRootPaths']);
+            $view->getRenderingContext()->setControllerAction($templateName);
+        } else {
+            // TYPO3 v14+ (StandaloneView removed)
+            $viewFactoryData = new \TYPO3\CMS\Core\View\ViewFactoryData(
+                templateRootPaths: $viewSettings['templateRootPaths'],
+                partialRootPaths: $viewSettings['partialRootPaths'],
+                layoutRootPaths: $viewSettings['layoutRootPaths'],
+                request: $GLOBALS['TYPO3_REQUEST'] ?? null,
+            );
+            /** @var \TYPO3\CMS\Core\View\ViewFactoryInterface $viewFactory */
+            $viewFactory = GeneralUtility::getContainer()->get(\TYPO3\CMS\Core\View\ViewFactoryInterface::class);
+            $view = $viewFactory->create($viewFactoryData);
+        }
 
         /** @var PageRenderer $pageRenderer */
-        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer = $this->pageRenderer;
         $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
             JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance($row['uid'])
         );
@@ -270,7 +287,7 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
         }
 
         try {
-            $html = $view->render();
+            $html = class_exists(StandaloneView::class) ? $view->render() : $view->render($templateName);
             return is_string($html) ? $html : '';
         } catch (\Exception $e) {
             $this->errorTitle = 'Error rendering preview';

--- a/Classes/UserFunc/ContentElementUserFunc.php
+++ b/Classes/UserFunc/ContentElementUserFunc.php
@@ -2,10 +2,12 @@
 
 namespace Blueways\BwStaticTemplate\UserFunc;
 
+use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ContentElementUserFunc
 {
+    #[AsAllowedCallable]
     public function getTemplateRootPath(string $content): string
     {
         if (str_starts_with($content, 'EXT:')) {
@@ -21,6 +23,7 @@ class ContentElementUserFunc
         return implode('/', $pathSegments);
     }
 
+    #[AsAllowedCallable]
     public function getTemplateName(string $content): string
     {
         if (str_starts_with($content, 'EXT:')) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,9 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Blueways\BwStaticTemplate\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -5,9 +5,9 @@
     'tt_content',
     'CType',
     [
-        'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.title',
-        'bw_static_template',
-        'tx_bwstatictemplate_pi1',
+        'label' => 'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.title',
+        'value' => 'bw_static_template',
+        'icon' => 'tx_bwstatictemplate_pi1',
     ],
     'html',
     'after'
@@ -83,7 +83,7 @@ $GLOBALS['TCA']['tt_content']['palettes']['templates'] = [
 
 $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
     'showitem' => '
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+        --div--;core.form.tabs:general,
             --palette--;;general,
             --palette--;;templates,
             --palette--;;json,
@@ -91,16 +91,16 @@ $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
         --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
             --palette--;;frames,
             --palette--;;appearanceLinks,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+        --div--;core.form.tabs:language,
             --palette--;;language,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
+        --div--;core.form.tabs:access,
             --palette--;;hidden,
             --palette--;;access,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
+        --div--;core.form.tabs:categories,
             categories,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
+        --div--;core.form.tabs:notes,
             rowDescription,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
+        --div--;core.form.tabs:extended,
     ',
 ];
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -83,7 +83,7 @@ $GLOBALS['TCA']['tt_content']['palettes']['templates'] = [
 
 $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
     'showitem' => '
-        --div--;core.form.tabs:general,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
             --palette--;;general,
             --palette--;;templates,
             --palette--;;json,
@@ -91,16 +91,16 @@ $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
         --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
             --palette--;;frames,
             --palette--;;appearanceLinks,
-        --div--;core.form.tabs:language,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
             --palette--;;language,
-        --div--;core.form.tabs:access,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
             --palette--;;hidden,
             --palette--;;access,
-        --div--;core.form.tabs:categories,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
             categories,
-        --div--;core.form.tabs:notes,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
             rowDescription,
-        --div--;core.form.tabs:extended,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
     ',
 ];
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-json": "*",
 		"ext-pdo": "*",
 		"blueways/bw-jsoneditor": "^2.0",
-		"typo3/cms-core": "^12.3 || ^13.4 || ^14.0"
+		"typo3/cms-core": "^13.4 || ^14.2"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
@@ -27,14 +27,13 @@
 		"codeception/module-phpbrowser": "^3.0",
 		"ergebnis/composer-normalize": "^2.44",
 		"friendsofphp/php-cs-fixer": "^3.12",
-		"friendsoftypo3/content-blocks": "^0.7.18 || ^1.0.0",
 		"helhum/typo3-console": "^8.1",
 		"helmich/typo3-typoscript-lint": "^3.2",
 		"move-elevator/composer-translation-validator": "^1.3",
-		"saschaegerer/phpstan-typo3": "^1.1 || ^2.1",
+		"saschaegerer/phpstan-typo3": "^2.1 || ^3.0",
 		"ssch/typo3-rector": "^2.10 || ^3.13",
-		"typo3/cms-base-distribution": "^12.0 || ^13.4",
-		"typo3/cms-lowlevel": "^12.0 || ^13.4"
+		"typo3/cms-base-distribution": "^13.4 || ^14.0",
+		"typo3/cms-lowlevel": "^13.4 || ^14.2"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-json": "*",
 		"ext-pdo": "*",
 		"blueways/bw-jsoneditor": "^2.0",
-		"typo3/cms-core": "^12.3 || ^13.4"
+		"typo3/cms-core": "^12.3 || ^13.4 || ^14.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
@@ -27,9 +27,8 @@
 		"friendsoftypo3/content-blocks": "^0.7.18 || ^1.0.0",
 		"helhum/typo3-console": "^8.1",
 		"helmich/typo3-typoscript-lint": "^3.2",
-		"nikic/php-parser": "4.19.4 as 5.3.1",
-		"saschaegerer/phpstan-typo3": "^1.1",
-		"ssch/typo3-rector": "^2.10",
+		"saschaegerer/phpstan-typo3": "^1.1 || ^2.0",
+		"ssch/typo3-rector": "^2.10 || ^3.0",
 		"symfony/translation": "^7.1",
 		"typo3/cms-base-distribution": "^12.0 || ^13.4",
 		"typo3/cms-lowlevel": "^12.0 || ^13.4"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,7 +6,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'templates',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-14.3.99',
+            'typo3' => '13.4.0-14.3.99',
             'bw_jsoneditor' => '2.0.0-2.99.99',
         ],
         'conflicts' => [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,7 +6,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'templates',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
+            'typo3' => '12.4.0-14.3.99',
             'bw_jsoneditor' => '2.0.0-2.99.99',
         ],
         'conflicts' => [

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 * This file is part of the TYPO3 CMS project.
 *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: Classes/PreviewRenderer/BackendPreviewRender.php
 
 		-
+			message: '#^Variable \$image might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
 			message: '#^Binary operation "\.\=" between mixed and '',tx…'' results in an error\.$#'
 			identifier: assignOp.invalid
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,66 @@ parameters:
 			path: Classes/PreviewRenderer/BackendPreviewRender.php
 
 		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Call to method assign\(\) on an unknown class TYPO3\\CMS\\Fluid\\View\\StandaloneView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Call to method render\(\) on an unknown class TYPO3\\CMS\\Fluid\\View\\StandaloneView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot call method getTemplatePaths\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot call method setControllerAction\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot call method setLayoutRootPaths\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot call method setPartialRootPaths\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot call method setTemplateRootPaths\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Instanceof between TYPO3\\CMS\\Core\\Domain\\RecordInterface and TYPO3\\CMS\\Core\\Domain\\RecordInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 2
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
 			message: '#^Binary operation "\.\=" between mixed and '',tx…'' results in an error\.$#'
 			identifier: assignOp.invalid
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,121 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		-
+			message: '#^Method Blueways\\BwStaticTemplate\\DataProcessing\\JsonProcessor\:\:process\(\) should return array\<string, array\<string, string\>\> but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/DataProcessing/JsonProcessor.php
+
+		-
+			message: '#^Binary operation "\." between ''\<p\>\<strong\>'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Binary operation "\.\=" between non\-falsy\-string and mixed results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Cannot access offset ''contentElement\.'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getJson\(\) should return array\<string, mixed\> but returns array\<mixed, mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getLanguageService\(\) should return TYPO3\\CMS\\Core\\Localization\\LanguageService but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderFluidBackendTemplate\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderTablePreview\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \#1 \$typoScriptArray of method TYPO3\\CMS\\Core\\TypoScript\\TypoScriptService\:\:convertTypoScriptArrayToPlainArray\(\) expects array\<int\|string, mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Parameter \$request of class TYPO3\\CMS\\Core\\View\\ViewFactoryData constructor expects Psr\\Http\\Message\\ServerRequestInterface\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Classes/PreviewRenderer/BackendPreviewRender.php
+
+		-
+			message: '#^Binary operation "\.\=" between mixed and '',tx…'' results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''bw_static_template'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''ctrl'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''json'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''label_alt'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''palettes'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''templates'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''tt_content'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''typeicon_classes'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php
+
+		-
+			message: '#^Cannot access offset ''types'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Configuration/TCA/Overrides/tt_content.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,62 +1,8 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method Blueways\\BwStaticTemplate\\DataProcessing\\JsonProcessor\:\:process\(\) should return array\<string, array\<string, string\>\> but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/DataProcessing/JsonProcessor.php
-
-		-
-			message: '#^Binary operation "\." between ''\<p\>\<strong\>'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
 			message: '#^Binary operation "\.\=" between non\-falsy\-string and mixed results in an error\.$#'
 			identifier: assignOp.invalid
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Cannot access offset ''contentElement\.'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getJson\(\) should return array\<string, mixed\> but returns array\<mixed, mixed\>\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:getLanguageService\(\) should return TYPO3\\CMS\\Core\\Localization\\LanguageService but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderFluidBackendTemplate\(\) expects array\<string, string\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \#1 \$row of method Blueways\\BwStaticTemplate\\PreviewRenderer\\BackendPreviewRender\:\:renderTablePreview\(\) expects array\<string, string\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \#1 \$typoScriptArray of method TYPO3\\CMS\\Core\\TypoScript\\TypoScriptService\:\:convertTypoScriptArrayToPlainArray\(\) expects array\<int\|string, mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Classes/PreviewRenderer/BackendPreviewRender.php
-
-		-
-			message: '#^Parameter \$request of class TYPO3\\CMS\\Core\\View\\ViewFactoryData constructor expects Psr\\Http\\Message\\ServerRequestInterface\|null, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: Classes/PreviewRenderer/BackendPreviewRender.php
 

--- a/rector.php
+++ b/rector.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\ValueObject\PhpVersion;
-use Ssch\TYPO3Rector\CodeQuality\General\ConvertImplicitVariablesToExplicitGlobalsRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
@@ -16,7 +15,6 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/Classes',
         __DIR__ . '/Configuration',
-        __DIR__ . '/config',
         __DIR__ . '/ext_emconf.php',
         __DIR__ . '/ext_tables.php',
     ])
@@ -26,7 +24,7 @@ return RectorConfig::configure()
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-        Typo3LevelSetList::UP_TO_TYPO3_13,
+        Typo3LevelSetList::UP_TO_TYPO3_14,
     ])
     // To have a better analysis from PHPStan, we teach it here some more things
     ->withPHPStanConfigs([
@@ -34,11 +32,10 @@ return RectorConfig::configure()
     ])
     ->withRules([
         AddVoidReturnTypeWhereNoReturnRector::class,
-        ConvertImplicitVariablesToExplicitGlobalsRector::class,
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.3.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-13.4.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.4.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-14.3.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     // If you use withImportNames(), you should consider excluding some TYPO3 files.

--- a/rector.php
+++ b/rector.php
@@ -34,7 +34,7 @@ return RectorConfig::configure()
         AddVoidReturnTypeWhereNoReturnRector::class,
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.4.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.2.0-8.4.99',
         ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-14.3.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ]);

--- a/rector.php
+++ b/rector.php
@@ -42,6 +42,8 @@ return RectorConfig::configure()
     ->withSkip([
         // @see https://github.com/sabbelasichon/typo3-rector/issues/2536
         __DIR__ . '/**/Configuration/ExtensionBuilder/*',
+        // Keep LLL:EXT: tab labels for TYPO3 v12 compatibility (core.form.tabs:* is v14+ only)
+        __DIR__ . '/Configuration/TCA/Overrides/tt_content.php',
         NameImportingPostRector::class => [
             'ext_localconf.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html
             'ext_tables.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\ValueObject\PhpVersion;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
@@ -21,11 +20,11 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     // ->withPhpSets()
-    ->withPhpVersion(PhpVersion::PHP_81)
+    ->withPhpVersion(PhpVersion::PHP_82)
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-        Typo3LevelSetList::UP_TO_TYPO3_12,
+        Typo3LevelSetList::UP_TO_TYPO3_13,
     ])
     // To have a better analysis from PHPStan, we teach it here some more things
     ->withPHPStanConfigs([
@@ -36,19 +35,6 @@ return RectorConfig::configure()
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
         ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.4.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-14.3.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-14.3.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
-    ])
-    // If you use withImportNames(), you should consider excluding some TYPO3 files.
-    ->withSkip([
-        // @see https://github.com/sabbelasichon/typo3-rector/issues/2536
-        __DIR__ . '/**/Configuration/ExtensionBuilder/*',
-        // Keep LLL:EXT: tab labels for TYPO3 v12 compatibility (core.form.tabs:* is v14+ only)
-        __DIR__ . '/Configuration/TCA/Overrides/tt_content.php',
-        NameImportingPostRector::class => [
-            'ext_localconf.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html
-            'ext_tables.php', // This line can be removed since TYPO3 11.4, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html
-            'ClassAliasMap.php',
-        ],
-    ])
-;
+    ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated supported TYPO3 range to 13.4–14.x and added PHP 8.4 support.
* **Improvements**
  * More robust JSON content handling and merging for template data.
  * Improved backend preview rendering, thumbnail handling and template rendering across TYPO3 13/14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->