### PR TITLE
Re-add default header field

### DIFF
--- a/Classes/PreviewRenderer/BackendPreviewRender.php
+++ b/Classes/PreviewRenderer/BackendPreviewRender.php
@@ -38,15 +38,21 @@ class BackendPreviewRender extends StandardContentPreviewRenderer
         /** @var array<string, string|int|null> $row */
         $row = $record instanceof RecordInterface ? $item->getRow() : $record;
 
+        // template name intro block
+        if ($row['tx_bwstatictemplate_template_path']) {
+            $html = $this->linkEditContent(
+                '<p class="text-muted"><small>' . htmlspecialchars((string)$row['tx_bwstatictemplate_template_path']) . '</small></p>',
+                $record
+            );
+        }
+
         // custom preview
         if ($row['tx_bwstatictemplate_be_template']) {
-            $html = $this->renderFluidBackendTemplate($row);
+            $html .= $this->renderFluidBackendTemplate($row);
         }
 
         // default view
         if (!$row['tx_bwstatictemplate_be_template']) {
-            $html = $row['tx_bwstatictemplate_template_path'] ? '<p><strong>' . $row['tx_bwstatictemplate_template_path'] . '</strong></p>' : '';
-            $html = $this->linkEditContent($html, $record);
             $pageRenderer = $this->pageRenderer;
             $pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@maikschneider/bw-static-template/backend.js')->instance()

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -85,6 +85,7 @@ $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
     'showitem' => '
         --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
             --palette--;;general,
+            --palette--;;header,
             --palette--;;templates,
             --palette--;;json,
             assets,

--- a/Tests/Fixtures/tt_content.sql
+++ b/Tests/Fixtures/tt_content.sql
@@ -1,7 +1,7 @@
-replace into `tt_content` (`uid`, `pid`, `CType`, `tx_bwstatictemplate_template_path`, `tx_bwstatictemplate_json`, `assets`, `sys_language_uid`, `l18n_parent`, `colPos`)
-values (1, 2, 'bw_static_template', '', null, 0, 0, 0, 0),
-			 (2, 3, 'bw_static_template', 'EXT:bw_static_template/Tests/Fixtures/Templates/TestTemplate.html', null, 0, 0, 0, 0),
-			 (3, 4, 'bw_static_template', 'TestTemplate', null, 0, 0, 0, 0),
-			 (4, 5, 'bw_static_template', 'JsonTemplate', '{"headline":"Hello from JSON","color":"blue"}', 0, 0, 0, 0),
-			 (5, 6, 'bw_static_template', 'FilesTemplate', null, 1, 0, 0, 0),
-			 (6, 7, 'bw_static_template', 'JsonTemplate', '{not valid json}', 0, 0, 0, 0);
+replace into `tt_content` (`uid`, `pid`, `header`, `CType`, `tx_bwstatictemplate_template_path`, `tx_bwstatictemplate_json`, `assets`, `sys_language_uid`, `l18n_parent`, `colPos`)
+values (1, 2, '', 'bw_static_template', '', null, 0, 0, 0, 0),
+			 (2, 3, 'EXT Path Template', 'bw_static_template', 'EXT:bw_static_template/Tests/Fixtures/Templates/TestTemplate.html', null, 0, 0, 0, 0),
+			 (3, 4, 'Template Name Only', 'bw_static_template', 'TestTemplate', null, 0, 0, 0, 0),
+			 (4, 5, 'JSON Variables', 'bw_static_template', 'JsonTemplate', '{"headline":"Hello from JSON","color":"blue"}', 0, 0, 0, 0),
+			 (5, 6, 'File Injection', 'bw_static_template', 'FilesTemplate', null, 1, 0, 0, 0),
+			 (6, 7, 'Invalid JSON', 'bw_static_template', 'JsonTemplate', '{not valid json}', 0, 0, 0, 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template preview now displays a template name intro block when a template path is present.
  * Header field is now available in the template content type configuration.

* **Bug Fixes**
  * Custom Fluid backend template output is now properly appended to existing content instead of being replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->