### PR TITLE
Migrate to v13 element registration via TCA CType group

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,9 +1,9 @@
 <?php
 
-call_user_func(function () {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
-        'bw_static_template',
-        'Configuration/page.tsconfig',
-        'Bw Static Template'
-    );
-});
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::registerPageTSConfigFile(
+    'bw_static_template',
+    'Configuration/TSconfig/page.tsconfig',
+    'Bw Static Template'
+);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,9 +1,9 @@
 <?php
 
-call_user_func(function () {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-        'bw_static_template',
-        'Configuration/TypoScript',
-        'Bw Static Template'
-    );
-});
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::addStaticFile(
+    'bw_static_template',
+    'Configuration/TypoScript',
+    'Bw Static Template'
+);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,13 +1,18 @@
 <?php
 
 // register CType
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(
+use Blueways\BwStaticTemplate\PreviewRenderer\BackendPreviewRender;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
         'label' => 'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.title',
         'value' => 'bw_static_template',
         'icon' => 'tx_bwstatictemplate_pi1',
+        'description' => 'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.description',
+        'group' => 'special',
     ],
     'html',
     'after'
@@ -69,7 +74,7 @@ $tempFields = [
     ],
 ];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $tempFields);
+ExtensionManagementUtility::addTCAcolumns('tt_content', $tempFields);
 
 $GLOBALS['TCA']['tt_content']['palettes']['json'] = [
     'label' => 'LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:jsonPalette',
@@ -105,6 +110,6 @@ $GLOBALS['TCA']['tt_content']['types']['bw_static_template'] = [
     ',
 ];
 
-$GLOBALS['TCA']['tt_content']['types']['bw_static_template']['previewRenderer'] = \Blueways\BwStaticTemplate\PreviewRenderer\BackendPreviewRender::class;
+$GLOBALS['TCA']['tt_content']['types']['bw_static_template']['previewRenderer'] = BackendPreviewRender::class;
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['bw_static_template'] = 'tx_bwstatictemplate_pi1';
 $GLOBALS['TCA']['tt_content']['ctrl']['label_alt'] .= ',tx_bwstatictemplate_template_path';

--- a/Configuration/TSconfig/page.tsconfig
+++ b/Configuration/TSconfig/page.tsconfig
@@ -1,0 +1,2 @@
+# Remove the exclusion of the content element
+TCEFORM.tt_content.CType.removeItems := removeFromList(bw_static_template)

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,13 +1,2 @@
-mod.wizards.newContentElement.wizardItems.special {
-  elements {
-    bwstatictemplate_pi1 {
-      iconIdentifier = tx_bwstatictemplate_pi1
-      title = LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.title
-      description = LLL:EXT:bw_static_template/Resources/Private/Language/locallang.xlf:pi1.wizard.description
-      tt_content_defValues {
-        CType = bw_static_template
-      }
-    }
-  }
-  show := addToList(bwstatictemplate_pi1)
-}
+# Remove content element from CType selection and new element wizard (should not be available globally)
+TCEFORM.tt_content.CType.removeItems := addToList(bw_static_template)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ composer require blueways/bw-static-template
 @import 'EXT:bw_static_template/Configuration/TypoScript/setup.typoscript'
 ```
 
+3. Include static PageTS template or manually import it:
+
+```typoscript
+@import 'EXT:bw_static_template/Configuration/TSconfig/page.typoscript'
+```
+
 ## Usage
 
 Add the content element **Static Template** to a page


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Changes**
  * Removed the "bw_static_template" content element from the new-content wizard and from content type selection so it no longer appears as an option.

* **Documentation**
  * Added instructions to include the extension’s static PageTS configuration.

* **Refactor**
  * Reorganized configuration placement and simplified registration calls for clearer maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->